### PR TITLE
Use system ruby in shebang

### DIFF
--- a/bin/setup-oob
+++ b/bin/setup-oob
@@ -1,4 +1,4 @@
-#!/opt/chef/embedded/bin/ruby
+#!/usr/bin/env ruby
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2021-present Vicarious


### PR DESCRIPTION
This is currently hardcoded to the embedded Chef ruby, which isn't generally available unless one has Chef installed. Switch to the system one instead.

(moved over from https://github.com/vicariousinc/setup-oob/pull/4)