### PR TITLE
Fixup CI

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,17 @@
+name: DCO Check
+on: [pull_request]
+
+jobs:
+  dco_check_job:
+    runs-on: ubuntu-latest
+    name: DCO Check
+    steps:
+    - name: Get PR Commits
+      uses: tim-actions/get-pr-commits@master
+      id: 'get-pr-commits'
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: DCO Check
+      uses: tim-actions/dco@master
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,15 +1,13 @@
-name: Continuous Integration
+name: Lint
 on:
   push:
     branches: [main]
   pull_request:
   workflow_dispatch:
 jobs:
-  ruby:
+  rubocop:
     strategy:
       fail-fast: false
-      matrix:
-        ruby: [3.0, 3.1, 3.2, 3.3]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -17,7 +15,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}
+        ruby-version: '3.2'
     - name: Install dependencies
       run: bundle install
     - name: Run rubocop

--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 # Setup OOB
 
-[![Continuous Integration](https://github.com/jaymzh/setup-oob/workflows/Continuous%20Integration/badge.svg)](https://github.com/jaymzh/setup-oob/actions?query=workflow%3AContinuous%20Integration)
-
-*NOTE*: This is a fork of
-[viariousinc/setup-oob](https://github.com/vicariousinc/setup-oob) which is
-defunct. This is now the official respository, feel free to send PRs or issues
-here.
+[![Lint](https://github.com/jaymzh/setup-oob/workflows/Lint/badge.svg)](https://github.com/jaymzh/setup-oob/actions?query=workflow%3ALint)
+[![DCO](https://github.com/jaymzh/setup-oob/workflows/DCO%20Check/badge.svg)](https://github.com/jaymzh/setup-oob/actions?query=workflow%3A%22DCO+Check%22)
 
 This is a utility for configuring out-of-band management systems from within
 the running (Linux) OS.
@@ -90,3 +86,10 @@ option.
 
 Setup OOB requires `ipmitool` at a minimum. For SMC hosts, that is the only
 requirement. For DRAC hosts, it also requires racadm.
+
+## History
+
+This is a fork of
+[viariousinc/setup-oob](https://github.com/vicariousinc/setup-oob) which is
+defunct. This is now the official respository, feel free to send PRs or issues
+here.


### PR DESCRIPTION
* the "CI" was just lint, and that doesn't need to run on
  different versions of ruby, rename it, drop matrix
* Add DCO checks

Signed-off-by: Phil Dibowitz <phil@ipom.com>
